### PR TITLE
When client is destroyed break the loop instead of return

### DIFF
--- a/packages/tdl/src/client.js
+++ b/packages/tdl/src/client.js
@@ -335,7 +335,7 @@ export class Client {
       try {
         const response = await this._receive()
 
-        if (!this._client) return
+        if (!this._client) break
 
         if (this._paused === true)
           await this._waitResume()


### PR DESCRIPTION
In the loop, when `client` is destroyed using `return` breaks the process when running tdl on web servers while `break` allows for the processes to continue. 