### PR TITLE
non blocking event loop iterUpdates

### DIFF
--- a/packages/tdl/src/client.ts
+++ b/packages/tdl/src/client.ts
@@ -293,17 +293,17 @@ export class Client {
         new Promise((resolve, reject) => {
           setTimeout(() => {
             if (!unconsumedEvents.isEmpty()) {
-              const update = unconsumedEvents.shift()!;
-              return resolve({ done: false, value: update });
+              const update = unconsumedEvents.shift()!
+              return resolve({ done: false, value: update })
             }
-            if (finished) return resolve({ done: true, value: undefined });
+            if (finished) return resolve({ done: true, value: undefined })
             if (defer != null) {
-              finish();
-              return reject(new Error("Cannot call next() twice in succession"));
+              finish()
+              return reject(new Error("Cannot call next() twice in succession"))
             }
 
-            defer = { resolve, reject };
-          }, 0);
+            defer = { resolve, reject }
+          }, 0)
         }),
 
       return () {


### PR DESCRIPTION
Your implementation is blocking the event loop. For example, if you run several clients in the same process and use iterUpdates in one of them, then the second client will not be able to perform any operations.

I have prepared code examples to explain what I mean.

Blocking
```js
'use strict';

const range = {
  start: 1,
  end: 1000,
  [Symbol.asyncIterator]() {
    let value = this.start;
    return {
      next: () => Promise.resolve({
        value,
        done: value++ === this.end + 1
      })
    };
  }
};

// it will be output only after the end of the iterator
setTimeout(() => {
  console.log('setTimeout 0');
}, 0);

(async () => {
  for await (const number of range) {
    console.log(number);
  }
})();
```

Non-blocking
```js
'use strict';

const range = {
  start: 1,
  end: 1000,
  [Symbol.asyncIterator]() {
    let value = this.start;
    return {
      next: () => new Promise(resolve => {
        setTimeout(() => {
          resolve({
            value,
            done: value++ === this.end + 1
          });
        }, 0);
      })
    };
  }
};

let k = 0;

// it will be output because the asynchronous iterator will return the tick to the event loop
const timer = setInterval(() => {
  console.log('next ', k++);
}, 10);

(async () => {
  for await (const number of range) {
    console.log(number);
    if (number === range.end) {
      clearInterval(timer);
    }
  }
})();
```
My solution allows you to give a tick after scrolling the iterator. I also use one common promise, which saves resources and increases productivity.
